### PR TITLE
transfer props to handler to fix state propagation

### DIFF
--- a/lib/Router.js
+++ b/lib/Router.js
@@ -29,7 +29,7 @@ function createRouter(name, component) {
     },
 
     render: function() {
-      var handler = this.renderRouteHandler();
+      var handler = this.transferPropsTo(this.renderRouteHandler());
       return this.transferPropsTo(this.props.component(null, handler));
     }
   });


### PR DESCRIPTION
Hi Andrey - I found that passing props from the Router wasn't reflecting the state of the parent as it updated. Ie:

```
<Locations user={this.state.user}>
<Location path="/" handler={IndexHandler}>
</Locations>
```

Changes to the `user` state aren't being reflected in the `user` prop for `IndexHandler`.

`transferPropsTo` the handler directly fixed this issue for me. Is there a better way to go about this? Also, why the `React.Div` between the main Router component and the matched Handler? Seems redundant since the Handler will be a single root element and actual React component anyways?

Thanks again
