### PR TITLE
Add fallback for browsers without pushState

### DIFF
--- a/lib/environment/PathnameEnvironment.js
+++ b/lib/environment/PathnameEnvironment.js
@@ -2,6 +2,9 @@
 
 var Environment = require('./Environment');
 
+var pushStateIsSupported = (window.history !== undefined &&
+                            window.history.pushState !== undefined);
+
 /**
  * Routing environment which routes by `location.pathname`.
  */
@@ -18,11 +21,19 @@ PathnameEnvironment.prototype.getPath = function() {
 }
 
 PathnameEnvironment.prototype.pushState = function(path, navigation) {
-  window.history.pushState({}, '', path);
+  if (pushStateIsSupported) {
+    window.history.pushState({}, '', path);
+  } else {
+    window.location.href = path;
+  }
 }
 
 PathnameEnvironment.prototype.replaceState = function(path, navigation) {
-  window.history.replaceState({}, '', path);
+  if (pushStateIsSupported) {
+    window.history.replaceState({}, '', path);
+  } else {
+    window.location.replace(path);
+  }
 }
 
 PathnameEnvironment.prototype.start = function() {

--- a/lib/environment/index.js
+++ b/lib/environment/index.js
@@ -24,10 +24,7 @@ if (ExecutionEnvironment.canUseDOM) {
 
   pathnameEnvironment = new PathnameEnvironment();
   hashEnvironment     = new HashEnvironment();
-  defaultEnvironment  = (window.history !== undefined &&
-                         window.history.pushState !== undefined) ?
-                        pathnameEnvironment :
-                        hashEnvironment;
+  defaultEnvironment  = pathnameEnvironment;
 
 } else {
 


### PR DESCRIPTION
Previously, the defaultEnvironment would be set to an instance of
HashEnvironment if pushState wasn't supported. However, this was broken by
default if doing server rendering because those browsers wouldn't get their
initial path from window.location.
