### PR TITLE
Better route matching support #40

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ See [docs][] for the usage.
 [server-side]: http://strml.viewdocs.io/react-router-component/server-side
 [multiple]: http://strml.viewdocs.io/react-router-component/multiple
 [contextual]: http://strml.viewdocs.io/react-router-component/contextual
-[url-pattern]: http://strml.viewdocs.io/react-router-component/url-pattern
+[url-match]: http://strml.viewdocs.io/react-router-component/url-pattern
 [async]: http://strml.viewdocs.io/react-router-component/async
 
 [docs]: http://strml.viewdocs.io/react-router-component

--- a/lib/matchRoutes.js
+++ b/lib/matchRoutes.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var pattern   = require('url-pattern');
+var urlMatch   = require('url-match');
 var mergeInto = require('react/lib/mergeInto');
 var invariant = require('react/lib/invariant');
 
@@ -30,15 +30,27 @@ function matchRoutes(routes, path) {
     }
 
     if (current.path) {
-      current.pattern = current.pattern || pattern.newPattern(current.path);
+      if (!current.urlMatch && !current.pattern) {
+        if (current.path.constructor == RegExp) {
+          current.pattern = current.path;
+        } else {
+          current.urlMatch = urlMatch.generate(current.path);
+        }
+      }
       if (!page) {
-        match = current.pattern.match(path);
+        if (current.urlMatch) {
+          match = current.urlMatch.match(path);
+        }
+        else {
+          console.log(path, current.pattern)
+          match = path.match(current.pattern)
+          // Regex matches are not named, so they go in the `_` array, much like splats.
+          if (Array.isArray(match)) {
+            match = {_: match.slice(1)};
+          }
+        }
         if (match) {
           page = current;
-        }
-        // Regex matches are not named, so they go in the `_` array, much like splats.
-        if (Array.isArray(match)) {
-          match = {_: match};
         }
       }
     }
@@ -76,7 +88,8 @@ function Match(path, route, match) {
 Match.prototype.getHandler = function() {
   var props = {};
   if (this.match) {
-    mergeInto(props, this.match);
+    mergeInto(props, this.match.namedParams);
+    props.queryParams = this.match.queryParams;
   }
   if (this.route && this.route.props) {
     mergeInto(props, this.route.props);

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "Declarative router component for React",
   "main": "index.js",
   "dependencies": {
+    "url-match": "~0.1.0",
     "envify": "^1.2.1",
     "react": "^0.11.1",
-    "url-pattern": "~0.6.0",
     "urllite": "~0.4.0"
   },
   "peerDependencies": {

--- a/tests/matchRoutes.js
+++ b/tests/matchRoutes.js
@@ -11,7 +11,6 @@ describe('matchRoutes', function() {
   var routes = [
     {path: '(/)', handler: handler({name: 'root'})},
     {path: '/cat/:id', handler: handler({name: 'cat'})},
-    {path: '/mod/*', handler: handler({name: 'mod'})},
     {path: /\/regex\/([a-zA-Z]*)$/, handler: handler({name: 'regex'})},
     {path: null, handler: handler({name: 'notfound'})}
   ];
@@ -20,7 +19,7 @@ describe('matchRoutes', function() {
     var match = matchRoutes(routes, '');
     assert(match.route);
     assert.strictEqual(match.route.handler.name, 'root');
-    assert.deepEqual(match.match, {});
+    assert.deepEqual(match.match, {namedParams: {}, queryParams: {}});
     assert.strictEqual(match.path, '');
     assert.strictEqual(match.matchedPath, '');
     assert.strictEqual(match.unmatchedPath, null);
@@ -30,7 +29,7 @@ describe('matchRoutes', function() {
     var match = matchRoutes(routes, '/');
     assert(match.route);
     assert.strictEqual(match.route.handler.name, 'root');
-    assert.deepEqual(match.match, {});
+    assert.deepEqual(match.match, {namedParams: {}, queryParams: {}});
     assert.strictEqual(match.path, '/');
     assert.strictEqual(match.matchedPath, '/');
     assert.strictEqual(match.unmatchedPath, null);
@@ -40,20 +39,10 @@ describe('matchRoutes', function() {
     var match = matchRoutes(routes, '/cat/hello');
     assert(match.route);
     assert.strictEqual(match.route.handler.name, 'cat');
-    assert.deepEqual(match.match, {id: 'hello'});
+    assert.deepEqual(match.match, {namedParams: {id: 'hello'}, queryParams: {}});
     assert.strictEqual(match.path, '/cat/hello');
     assert.strictEqual(match.matchedPath, '/cat/hello');
     assert.strictEqual(match.unmatchedPath, null);
-  });
-
-  it('matches /mod/wow/here', function() {
-    var match = matchRoutes(routes, '/mod/wow/here');
-    assert(match.route);
-    assert.strictEqual(match.route.handler.name, 'mod');
-    assert.deepEqual(match.match, {_: ['wow/here']});
-    assert.strictEqual(match.path, '/mod/wow/here');
-    assert.strictEqual(match.matchedPath, '/mod/');
-    assert.strictEqual(match.unmatchedPath, 'wow/here');
   });
 
   it('matches /regex/text', function() {


### PR DESCRIPTION
I am missing a piece of functionality regarding query parameters. I would that whenever the route changes it's query parameters, those are passed as properties as well to the component handler of the route. For example:

```
<Locations>
    <Location path="/users/:userId/posts" handler="PostsPage" />
</Locations>
```

So when navigating to "/users/123/posts?sort=name&page=2" would be generated with:

```
<PostsPage userId="123" queryParams={ {sort: "name", page: "2"} } />
```

Right now the route matching is not as powerful as it could be.
- When query parameters differ, the route doesn't match (related to #38).
- Using \* at the end is not a great alternative as it could match nested paths.
- Using a regular expression makes us lose the very much convenient userId property in the child component.

So far, my best experience with javascript routers has been the [backbone](http://backbonejs.org) router together with [backbone-query-parameters](https://github.com/jhudson8/backbone-query-parameters) plugin (tried a few more like [director](https://github.com/flatiron/director) not very well maintained and with quite a few problems). 

Right now I am trying to re-implement the behavior mentioned based on the Backbone implementation. Does this look interesting and reasonable to you? Feedback is very much appreciated.
