### PR TITLE
Replace url-pattern with path-to-regexp

### DIFF
--- a/lib/Match.js
+++ b/lib/Match.js
@@ -8,15 +8,27 @@ var mergeInto = require('react/lib/mergeInto');
  *
  * @private
  */
-function Match(path, route, match) {
+function Match(path, route, matches) {
   this.path = path;
   this.route = route;
-  this.match = match;
-  this.isNotFound = match === null;
+  this.match = null;
+  this.isNotFound = matches === null;
+  this.unmatchedPath = null;
 
-  this.unmatchedPath = this.match && this.match._ ?
-    this.match._[0] :
-    null;
+  if (this.route) {
+    var keys = this.route.keys;
+    if (keys) {
+      this.match = {};
+      for (var i = 0, len = keys.length; i < len; i++) {
+        var key = keys[i];
+        this.match[key.name] = matches[i + 1];
+      }
+    }
+
+    this.unmatchedPath = matches && matches.length > keys.length + 1 ?
+      matches[this.route.keys.length + 1] :
+      null;
+  }
 
   this.matchedPath = this.unmatchedPath ?
     this.path.substring(0, this.path.length - this.unmatchedPath.length) :

--- a/lib/Route.js
+++ b/lib/Route.js
@@ -1,8 +1,8 @@
 "use strict";
 
-var invariant = require('react/lib/invariant');
-var merge     = require('react/lib/merge');
-var mergeInto = require('react/lib/mergeInto');
+var invariant     = require('react/lib/invariant');
+var merge         = require('react/lib/merge');
+var mergeInto     = require('react/lib/mergeInto');
 
 /**
  * Create a new route descriptor from a specification.
@@ -14,13 +14,16 @@ function createRoute(spec, defaults) {
 
   var handler = spec.handler;
   var path = spec.path;
+  var pattern = spec.pattern;
   var props = merge({}, spec);
 
-  delete props.path;
   delete props.handler;
+  delete props.path;
+  delete props.pattern;
 
   var route = {
     path: path,
+    pattern: pattern,
     handler: handler,
     props: props
   };
@@ -41,8 +44,8 @@ function createRoute(spec, defaults) {
   );
 
   invariant(
-    route.path !== undefined,
-    "Route should have an URL pattern specified: %s", handler
+    route.path !== undefined || route.pattern !== undefined,
+    "Route should have a path or URL pattern specified: %s", handler
   );
 
   return route;
@@ -63,7 +66,7 @@ function Route(spec) {
  * @param {Object} spec
  */
 function NotFound(spec) {
-  return createRoute(spec, {path: null});
+  return createRoute(spec, {pattern: null});
 }
 
 module.exports = {

--- a/lib/matchRoutes.js
+++ b/lib/matchRoutes.js
@@ -1,8 +1,8 @@
 "use strict";
 
-var pattern   = require('url-pattern');
-var invariant = require('react/lib/invariant');
-var Match     = require('./Match');
+var pathToRegexp  = require('path-to-regexp');
+var invariant     = require('react/lib/invariant');
+var Match         = require('./Match');
 
 /**
  * Match rotues against a path
@@ -11,7 +11,7 @@ var Match     = require('./Match');
  * @param {String} path
  */
 function matchRoutes(routes, path) {
-  var match, page, notFound;
+  var route, match, notFound;
 
   if (!Array.isArray(routes)) {
     routes = [routes];
@@ -22,28 +22,31 @@ function matchRoutes(routes, path) {
 
     if (process.env.NODE_ENV !== "production") {
       invariant(
-        current.handler !== undefined && current.path !== undefined,
+        current.handler !== undefined && (current.path !== undefined || current.pattern !== undefined),
         "Router should contain either Route or NotFound components " +
         "as routes")
     }
 
-    if (current.path) {
-      current.pattern = current.pattern || pattern(current.path);
-      if (!page) {
-        match = current.pattern.match(path);
+    if (current.path || current.pattern) {
+      if (!current.pattern) {
+        current.keys = current.keys || [];
+        current.pattern = pathToRegexp(current.path, current.keys);
+      }
+      if (!route) {
+        match = current.pattern.exec(path);
         if (match) {
-          page = current;
+          route = current;
         }
       }
     }
-    if (!notFound && current.path === null) {
+    if (!notFound && (current.path === null || current.pattern === null)) {
       notFound = current;
     }
   }
 
   return new Match(
     path,
-    page ? page : notFound ? notFound : null,
+    route ? route : notFound ? notFound : null,
     match
   );
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Declarative router component for React",
   "main": "index.js",
   "dependencies": {
-    "url-pattern": "~0.4.0",
     "envify": "^1.2.1",
+    "path-to-regexp": "~0.1.2",
     "urllite": "~0.4.0"
   },
   "peerDependencies": {

--- a/tests/matchRoutes.js
+++ b/tests/matchRoutes.js
@@ -11,6 +11,8 @@ describe('matchRoutes', function() {
     {path: '/', handler: handler({name: 'root'})},
     {path: '/cat/:id', handler: handler({name: 'cat'})},
     {path: '/mod/*', handler: handler({name: 'mod'})},
+    {path: '/dog/*/pups', keys: [{name: 'lineage'}], handler: handler({name: 'dog'})},
+    {pattern: /^\/catalogue\/([0-9]+)\/([0-9]+)$/, keys: [{name: 'category'}, {name: 'product'}], handler: handler({name: 'catalogue'})},
     {path: null, handler: handler({name: 'notfound'})}
   ];
 
@@ -38,10 +40,29 @@ describe('matchRoutes', function() {
     var match = matchRoutes(routes, '/mod/wow/here');
     assert(match.route);
     assert.strictEqual(match.route.handler.name, 'mod');
-    assert.deepEqual(match.match, {_: ['wow/here']});
     assert.strictEqual(match.path, '/mod/wow/here');
     assert.strictEqual(match.matchedPath, '/mod/');
     assert.strictEqual(match.unmatchedPath, 'wow/here');
+  });
+
+  it('matches /dog/first/second/pups', function() {
+    var match = matchRoutes(routes, '/dog/first/second/pups');
+    assert(match.route);
+    assert.strictEqual(match.route.handler.name, 'dog');
+    assert.deepEqual(match.match, {lineage: 'first/second'});
+    assert.strictEqual(match.path, '/dog/first/second/pups');
+    assert.strictEqual(match.matchedPath, '/dog/first/second/pups');
+    assert.strictEqual(match.unmatchedPath, null);
+  });
+
+  it('matches /catalogue/42/1337', function() {
+    var match = matchRoutes(routes, '/catalogue/42/1337');
+    assert(match.route);
+    assert.strictEqual(match.route.handler.name, 'catalogue');
+    assert.deepEqual(match.match, {category: 42, product: 1337});
+    assert.strictEqual(match.path, '/catalogue/42/1337');
+    assert.strictEqual(match.matchedPath, '/catalogue/42/1337');
+    assert.strictEqual(match.unmatchedPath, null);
   });
 
   it('handles not found', function() {


### PR DESCRIPTION
While [url-pattern](https://github.com/snd/url-pattern) works for most cases, [path-to-regexp](https://github.com/component/path-to-regexp) brings some added flexibility, such as optional trailing slashes and named wildcard capture groups.

This patch also allows each route to be specified using `pattern` (RegExp) instead of `path`.