### PR TITLE
Contextual routers and "index pages"

### DIFF
--- a/lib/matchRoutes.js
+++ b/lib/matchRoutes.js
@@ -58,11 +58,10 @@ function Match(path, route, match) {
   this.route = route;
   this.match = match;
 
-  this.unmatchedPath = this.match && this.match._ ?
-    this.match._[0] :
-    null;
+  var hasMatch = this.match && this.match._;
+  this.unmatchedPath = hasMatch ? this.match._[0] : "/";
 
-  this.matchedPath = this.unmatchedPath ?
+  this.matchedPath = hasMatch ?
     this.path.substring(0, this.path.length - this.unmatchedPath.length) :
     this.path;
 }

--- a/tests/matchRoutes.js
+++ b/tests/matchRoutes.js
@@ -21,7 +21,7 @@ describe('matchRoutes', function() {
     assert.deepEqual(match.match, {});
     assert.strictEqual(match.path, '/');
     assert.strictEqual(match.matchedPath, '/');
-    assert.strictEqual(match.unmatchedPath, null);
+    assert.strictEqual(match.unmatchedPath, '/');
   });
 
   it('matches /cat/:id', function() {
@@ -31,7 +31,7 @@ describe('matchRoutes', function() {
     assert.deepEqual(match.match, {id: 'hello'});
     assert.strictEqual(match.path, '/cat/hello');
     assert.strictEqual(match.matchedPath, '/cat/hello');
-    assert.strictEqual(match.unmatchedPath, null);
+    assert.strictEqual(match.unmatchedPath, '/');
   });
 
   it('matches /mod/wow/here', function() {
@@ -51,6 +51,6 @@ describe('matchRoutes', function() {
     assert.deepEqual(match.match, null);
     assert.strictEqual(match.path, '/hm');
     assert.strictEqual(match.matchedPath, '/hm');
-    assert.strictEqual(match.unmatchedPath, null);
+    assert.strictEqual(match.unmatchedPath, '/');
   });
 });


### PR DESCRIPTION
I have router that handles a `/profile` route using a contextual router. For example:

Parent router:

```
<Locations>
  <Location path="/profile" handler={ProfileRouter} />
  <Location path="/profile/*" handler={ProfileRouter} />
</Locations>
```

_ProfileRouter_ contextual router:

```
<Locations>
  <Location path="/" handler={ProfileIndexPage} />
  <Location path="/other" handler={ProfileOtherPage} />
</Location>
```

A request to `/profile` will cause an invariant violation because there is no `unmatchedPath` left from the parent router.

I want the _ProfileRouter_ contextual router to be able to handle requests for `/profile` as if there was a sort of "index page". It should match the _ProfileRouter_'s route for `/`.

This patch defaults the `unmatchedPath` portion of the _match_ object to `/` if there is no remaining match from the parent.

Ideally, I also wouldn't have to create two _Location_ components in the parent router and the `/profile/*` route could also match a request for `/profile`. This behavior could be behind a flag passed to _Location_.
