### PR TITLE
Inject ReactDefaultBatchingStrategy

### DIFF
--- a/lib/environment/Environment.js
+++ b/lib/environment/Environment.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var ReactUpdates  = require('react/lib/ReactUpdates');
+var DefaultBatchingStrategy = require('react/lib/ReactDefaultBatchingStrategy');
 
 /**
  * Base abstract class for a routing environment.
@@ -32,6 +33,7 @@ Environment.prototype.notify = function notify(navigation, cb) {
     }
   }
 
+  ReactUpdates.injection.injectBatchingStrategy(DefaultBatchingStrategy);
   ReactUpdates.batchedUpdates(function() {
     for (var i = 0, len = this.routers.length; i < len; i++) {
       this.routers[i].setPath(this.path, navigation, callback);


### PR DESCRIPTION
I'm not sure why this is the case, but any time I navigated (either using a link or popState) using the router, I would get the following error:

`Invariant Violation: ReactUpdates: must inject a batching strategy`

This seems to fix it, though I'm not sure why it was a problem in the first case. Not sure if this is a good fix or if there is something else wrong with my setup, as we're using react with addons.
