### PR TITLE
Fallback to default browser behavior for "special" clicks.

### DIFF
--- a/lib/Link.js
+++ b/lib/Link.js
@@ -26,6 +26,11 @@ var Link = React.createClass({
     if (this.props.onClick) {
       this.props.onClick(e);
     }
+
+    // return if the user did a middle-click, right-click, or used a modifier
+    // key (like ctrl-click, meta-click, shift-click, etc.)
+    if (e.button != 0 || e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) return;
+
     if (!e.defaultPrevented) {
       e.preventDefault();
       this._navigate(this.props.href, function(err) {


### PR DESCRIPTION
If the user did a middle-click, right-click, or used a modifier key (like ctrl-click, meta-click, shift-click, etc.), fallback to default browser behavior.
