### PR TITLE
fix missing navigation 3rd param that causes type errors

### DIFF
--- a/lib/NavigatableMixin.js
+++ b/lib/NavigatableMixin.js
@@ -27,8 +27,8 @@ var NavigatableMixin = {
     return this._getNavigable().getPath();
   },
 
-  navigate: function(path, cb) {
-    return this._getNavigable().navigate(path, cb);
+  navigate: function(path, navigation, cb) {
+    return this._getNavigable().navigate(path, navigation, cb);
   },
 
   makeHref: function(path) {

--- a/lib/environment/DummyEnvironment.js
+++ b/lib/environment/DummyEnvironment.js
@@ -17,7 +17,7 @@ DummyEnvironment.prototype.constructor = DummyEnvironment;
 
 DummyEnvironment.prototype.getPath = emptyFunction.thatReturnsNull;
 
-DummyEnvironment.prototype.setPath = function(path, cb) {
+DummyEnvironment.prototype.setPath = function(path, navigation, cb) {
   this.path = path;
   cb();
 };


### PR DESCRIPTION
you updated environment, routermixin, and others to .navigate(path, navigation, cb) but not NavigatableMixin and DummyEnvironment. this breaks manual javascript navigation when using the mixin, or doing server side rendering (like react-quickstart) which uses DummyEnvironment. also causes type errors when the if (typeof navigation === 'function' && cb === undefined) check is done.
