### PR TITLE
Upgrade dependencies to React 0.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
     "urllite": "~0.4.0"
   },
   "peerDependencies": {
-    "react": "~0.10.0",
-    "react-async": "~0.9.1"
+    "react": "~0.11.0",
+    "react-async": "~0.10.1"
   },
   "devDependencies": {
-    "react": "~0.10.0",
-    "react-async": "~0.9.1",
+    "react": "~0.11.0",
+    "react-async": "~0.10.1",
     "semver": "~2.2.1",
     "mocha": "~1.17.1",
     "jshint": "~2.4.3",


### PR DESCRIPTION
Because of the _peer dependencies_ requirements, _react-router-component_ can't currently be installed with React 0.11. This change upgrades the `package.json` dependencies to React 0.11 and a newer version of _react-async_ that also depends on React 0.11.

**This change does not fix any incompatibilities with React 0.11 (see #66), it simply makes it possible to `npm install` this module alongside React 0.11.**
