### PR TITLE
Allow intra-page hash routing.

### DIFF
--- a/lib/CaptureClicks.js
+++ b/lib/CaptureClicks.js
@@ -99,7 +99,7 @@ var CaptureClicks = React.createClass({
     }.bind(this);
 
     this.props.environment.navigate(
-      url.pathname,
+      url.pathname + (url.hash.length > 1 ? url.hash : ''),
       {onBeforeNavigation: onBeforeNavigation},
       function(err, info) {
         if (err) {


### PR DESCRIPTION
Normally, CaptureClicks will completely ignore any hash changes, which prevents any sort of hash routing. It's very useful to have when e.g. you have a table of contents sort of system that links to anchors on the page.

I do the hash length check because without it, an `<a href="#" onClick={this.clickHandler}></a>` component will navigate. They are very useful to have if one wants to comply with a strict CSP.
