### PR TITLE
Update to React 0.11 and fix child context types.

### DIFF
--- a/lib/NavigatableMixin.js
+++ b/lib/NavigatableMixin.js
@@ -13,7 +13,7 @@ var Environment = require('./environment');
 var NavigatableMixin = {
 
   contextTypes: {
-    router: React.PropTypes.component,
+    router: React.PropTypes.any,
   },
 
   /**

--- a/lib/RouterMixin.js
+++ b/lib/RouterMixin.js
@@ -17,7 +17,7 @@ var RouterMixin = {
   },
 
   childContextTypes: {
-    router: React.PropTypes.component
+    router: React.PropTypes.any
   },
 
   getChildContext: function() {
@@ -27,7 +27,7 @@ var RouterMixin = {
   },
 
   contextTypes: {
-    router: React.PropTypes.component
+    router: React.PropTypes.any
   },
 
   getInitialState: function() {

--- a/package.json
+++ b/package.json
@@ -4,17 +4,18 @@
   "description": "Declarative router component for React",
   "main": "index.js",
   "dependencies": {
-    "url-pattern": "~0.6.0",
     "envify": "^1.2.1",
+    "react": "^0.11.1",
+    "url-pattern": "~0.6.0",
     "urllite": "~0.4.0"
   },
   "peerDependencies": {
-    "react": "~0.10.0",
-    "react-async": "~0.9.1"
+    "react": "~0.11.0",
+    "react-async": "~1.0.1"
   },
   "devDependencies": {
-    "react": "~0.10.0",
-    "react-async": "~0.9.1",
+    "react": "~0.11.0",
+    "react-async": "~1.0.1",
     "semver": "~2.2.1",
     "mocha": "~1.17.1",
     "jshint": "~2.4.3",

--- a/tests/server.js
+++ b/tests/server.js
@@ -100,14 +100,14 @@ describe('react-router-component (on server)', function() {
       var markup = React.renderComponentToString(App({path: '/x/nice/hello'}));
       assert(markup.match(/class="App"/));
       assert(markup.match(/class="X"/));
-      assert(markup.match(/href="&#x2f;x&#x2f;nice&#x2f;hi"/));
+      assert(markup.match(/href="\/x\/nice\/hi"/));
     });
 
     it ('renders global Link component with correct href (not scoped to a router)', function() {
       var markup = React.renderComponentToString(App({path: '/x/nice/hello2'}));
       assert(markup.match(/class="App"/));
       assert(markup.match(/class="X"/));
-      assert(markup.match(/href="&#x2f;hi"/));
+      assert(markup.match(/href="\/hi"/));
     });
 
   });


### PR DESCRIPTION
Unfortunately had to punt on PropTypes as I [couldn't find](https://groups.google.com/d/msg/reactjs/4i68_ly4iRM/zlbtMh4jgdgJ) any better option than `React.PropTypes.all`, but it works and it gets to ~0.11.

I don't see any documentation for the entity encoding change in 0.11 but perhaps I missed it. In any case that change was also required to pass tests.

This is a fix for #66 and supersedes #73.
