### PR TITLE
Fixed warning about directly calling a component.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 node_modules/
 bundle.js
+tests/*.jsx

--- a/Makefile
+++ b/Makefile
@@ -7,22 +7,22 @@ install link:
 	@npm $@
 
 lint:
-	@jshint index.js `find lib -name '*.js'`
+	@./node_modules/.bin/jshint index.js `find lib -name '*.js'`
 
 test: test-unit test-server
 	@echo "The browser test suite should be run before commit. Run 'make test-local' to run it."
 
 test-unit:
-	@mocha -R spec -b tests/matchRoutes.js
+	@./node_modules/.bin/mocha -R spec -b tests/matchRoutes.js
 
 test-server:
-	@mocha -R spec -b tests/server.js
+	@./node_modules/.bin/mocha -R spec -b tests/server.js
 
 test-local:
-	@zuul --local 3000  -- tests/browser.js
+	@./node_modules/.bin/zuul --local 3000  -- tests/browser.js
 
 test-cloud:
-	@zuul -- tests/browser.js
+	@./node_modules/.bin/zuul -- tests/browser.js
 
 release-patch: test lint
 	@$(call release,patch)

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ install link:
 	@npm $@
 
 lint:
-	@./node_modules/.bin/jshint index.js `find lib -name '*.js'`
+	@./node_modules/.bin/jsxhint index.js `find lib tests \( -iname \*.js -o -iname \*.jsx \)`
 
 test: test-unit test-server
 	@echo "The browser test suite should be run before commit. Run 'make test-local' to run it."

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ test-server:
 	@./node_modules/.bin/mocha -R spec -b tests/server.js
 
 test-local:
-	@./node_modules/.bin/zuul --local 3000  -- tests/browser.js
+	@./node_modules/.bin/jsx tests/browser-jsx.jsx > tests/browser-jsx.js
+	@./node_modules/.bin/zuul --local 3000  -- tests/browser.js tests/browser-jsx.js
 
 test-cloud:
 	@./node_modules/.bin/zuul -- tests/browser.js

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,8 @@ component's `render()` method:
 
 Alternatively, if you don't prefer JSX:
 
+    var Locations = React.createFactory(Router.Locations);
+    var Location = React.createFactory(Router.Location);
     Locations(null,
       Location({path: "/", handler: MainPage}),
       Location({path: "/users/:username", handler: UserPage}))
@@ -59,6 +61,11 @@ scope, cause JSX doesn't support namespaces yet:
     var Locations = Router.Locations
     var Location = Router.Location
 
+Otherwise, as of React 0.12, you must create factories:
+
+    var Locations = React.createFactory(Router.Locations)
+    var Location = React.createFactory(Router.Location)
+
 Now you can define your application as a regular React component which renders
 into `Locations` router:
 
@@ -88,7 +95,7 @@ successful location match.
 
 The final part is to render your `App` component which activates your router:
 
-    React.renderComponent(App(), document.body)
+    React.renderComponent(React.createElement(App), document.body)
 
 In case no location is matched router would render into an empty set of
 elements.

--- a/lib/AsyncRouteRenderingMixin.js
+++ b/lib/AsyncRouteRenderingMixin.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var merge               = require('react/lib/merge');
+var assign              = Object.assign || require('object.assign');
 var prefetchAsyncState  = require('react-async/lib/prefetchAsyncState');
 var isAsyncComponent    = require('react-async/lib/isAsyncComponent');
 var RouteRenderingMixin = require('./RouteRenderingMixin');
@@ -16,7 +16,7 @@ var AsyncRouteRenderingMixin = {
     var currentHandler = this.state && this.state.handler;
     var nextHandler = state && state.handler;
 
-    if (nextHandler &&
+    if (nextHandler && nextHandler.type && 
         isAsyncComponent(nextHandler) &&
         // if component's type is the same we would need to skip async state
         // update
@@ -42,8 +42,7 @@ var AsyncRouteRenderingMixin = {
       if (this.isMounted() &&
           this.state.pendingState &&
           this.state.pendingState.match === state.match) {
-
-        var nextState = merge(this.state.pendingState, {handler: handler});
+        var nextState = assign({}, this.state.pendingState, {handler: handler});
         this.replaceState(nextState, cb);
 
       }

--- a/lib/CaptureClicks.js
+++ b/lib/CaptureClicks.js
@@ -3,6 +3,7 @@
 var React       = require('react');
 var urllite     = require('urllite/lib/core');
 var Environment = require('./environment');
+var assign      = Object.assign || require('object.assign');
 
 /**
  * A container component which captures <a> clicks and, if there's a matching
@@ -109,11 +110,10 @@ var CaptureClicks = React.createClass({
   },
 
   render: function() {
-    var props = {
+    var props = assign({}, this.props, {
       onClick: this.onClick
-    };
-    return this.transferPropsTo(
-      this.props.component(props, this.props.children));
+    });
+    return this.props.component(props, this.props.children);
   }
 
 });

--- a/lib/Link.js
+++ b/lib/Link.js
@@ -3,6 +3,7 @@
 var React             = require('react');
 var NavigatableMixin  = require('./NavigatableMixin');
 var Environment       = require('./environment');
+var assign            = Object.assign || require('object.assign');
 
 /**
  * Link.
@@ -70,11 +71,11 @@ var Link = React.createClass({
   },
 
   render: function() {
-    var props = {
+    var props = assign({}, this.props, {
       onClick: this.onClick,
       href: this._createHref()
-    };
-    return this.transferPropsTo(React.DOM.a(props, this.props.children));
+    });
+    return React.DOM.a(props, this.props.children);
   }
 });
 

--- a/lib/Route.js
+++ b/lib/Route.js
@@ -1,69 +1,43 @@
 "use strict";
 
-var invariant = require('react/lib/invariant');
-var merge     = require('react/lib/merge');
-var mergeInto = require('react/lib/mergeInto');
+var React     = require('react');
 
-/**
- * Create a new route descriptor from a specification.
- *
- * @param {Object} spec
- * @param {?Object} defaults
- */
-function createRoute(spec, defaults) {
-
-  var handler = spec.handler;
-  var path = spec.path;
-  var ref = spec.ref;
-  var props = merge({}, spec);
-
-  delete props.path;
-  delete props.handler;
-  delete props.ref;
-
-  var route = {
-    path: path,
-    handler: handler,
-    props: props,
-    ref: ref
-  };
-
-  if (defaults) {
-    mergeInto(route, defaults);
-  }
-
-  invariant(
-    typeof route.handler === 'function',
-    "Route handler should be a component or a function but got: %s", handler
-  );
-
-  invariant(
-    route.path !== undefined,
-    "Route should have an URL pattern specified: %s", handler
-  );
-
-  return route;
-}
-
-/**
- * Regular route descriptor.
- *
- * @param {Object} spec
- */
-function Route(spec) {
-  return createRoute(spec);
-}
-
-/**
- * Catch all route descriptor.
- *
- * @param {Object} spec
- */
-function NotFound(spec) {
-  return createRoute(spec, {path: null});
+function createClass(name) {
+  return React.createClass({
+    propTypes: {
+      handler: React.PropTypes.oneOfType([
+        React.PropTypes.node,
+        React.PropTypes.func
+      ]).isRequired,
+      path: name === 'NotFound' ? 
+        function(props, propName) {
+          if (props[propName]) throw new Error("Don't pass a `path` to NotFound.");
+        }
+        : React.PropTypes.string.isRequired
+    },
+    getDefaultProps: function() {
+      if (name === 'NotFound') {
+        return {path: null};
+      }
+      return {};
+    },
+    render: function() {
+      throw new Error(name + " is not meant to be directly rendered.");
+    }
+  });
 }
 
 module.exports = {
-  Route: Route,
-  NotFound: NotFound
+  /**
+   * Regular route descriptor.
+   *
+   * @param {Object} spec
+   */
+  Route: createClass('Route'),
+  /**
+   * Catch all route descriptor.
+   *
+   * @param {Object} spec
+   */
+  NotFound: createClass('NotFound')
 };

--- a/lib/RouteRenderingMixin.js
+++ b/lib/RouteRenderingMixin.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var cloneWithProps  = require('react/lib/cloneWithProps');
+var cloneWithProps = require('react/lib/cloneWithProps');
 
 /**
  * Mixin for routers which implements the simplest rendering strategy.
@@ -8,8 +8,8 @@ var cloneWithProps  = require('react/lib/cloneWithProps');
 var RouteRenderingMixin = {
 
   renderRouteHandler: function() {
-    var ref = this.state.match.route && this.state.match.route.ref;
-    return cloneWithProps(this.state.handler, {ref: ref});
+    var handler = this.state.handler;
+    return cloneWithProps(handler, {ref: this.state.match.route.ref});
   }
 
 };

--- a/lib/Router.js
+++ b/lib/Router.js
@@ -3,6 +3,7 @@
 var React                     = require('react');
 var RouterMixin               = require('./RouterMixin');
 var AsyncRouteRenderingMixin  = require('./AsyncRouteRenderingMixin');
+var assign                    = Object.assign || require('object.assign');
 
 /**
  * Create a new router class
@@ -29,8 +30,12 @@ function createRouter(name, component) {
     },
 
     render: function() {
+      // Render the Route's handler.
       var handler = this.renderRouteHandler();
-      return this.transferPropsTo(this.props.component(null, handler));
+      // Pass all props except this component to the Router (containing div/body).
+      var props = assign({}, this.props);
+      delete props.component;
+      return this.props.component(props, handler);
     }
   });
 }

--- a/lib/RouterMixin.js
+++ b/lib/RouterMixin.js
@@ -2,7 +2,7 @@
 
 var React         = require('react');
 var invariant     = require('react/lib/invariant');
-var merge         = require('react/lib/merge');
+var assign        = Object.assign || require('object.assign');
 var matchRoutes   = require('./matchRoutes');
 var Environment   = require('./environment');
 
@@ -161,7 +161,7 @@ var RouterMixin = {
       navigation: navigation
     };
 
-    navigation = merge(navigation, {match: match});
+    assign(navigation, {match: match});
 
     if (this.props.onBeforeNavigation &&
         this.props.onBeforeNavigation(path, navigation) === false) {

--- a/lib/matchRoutes.js
+++ b/lib/matchRoutes.js
@@ -82,14 +82,28 @@ function Match(path, route, match) {
 
 Match.prototype.getHandler = function() {
   if (!this.route) return undefined;
-  var factory = React.createFactory(this.route.props.handler);
+
   var props = assign({}, this.route.props, this.match);
+  var handler = this.route.props.handler;
 
   delete props.pattern;
   delete props.path;
   delete props.handler;
 
-  return factory(props);
+  // Handler was created with React.createClass
+  if (handler.isReactLegacyFactory) {
+    return React.createFactory(handler)(props);
+  }
+
+  // We assume the handler is a normal function
+  var instance = handler(props);
+
+  // It returned a factory
+  if (instance.isReactLegacyFactory) {
+    instance = React.createFactory(instance)(props);
+  }
+
+  return instance;
 }
 
 module.exports = matchRoutes;

--- a/lib/matchRoutes.js
+++ b/lib/matchRoutes.js
@@ -1,8 +1,9 @@
 "use strict";
 
 var pattern   = require('url-pattern');
-var mergeInto = require('react/lib/mergeInto');
+var assign    = Object.assign || require('object.assign');
 var invariant = require('react/lib/invariant');
+var React     = require('react');
 
 /**
  * Match routes against a path
@@ -22,17 +23,23 @@ function matchRoutes(routes, path) {
     // Simply skip null or undefined to allow ternaries in route definitions
     if (!current) continue;
 
+    // We expect to be passed an Element. If we weren't, and were just passed props,
+    // mock an Element's structure.
+    if (!React.isValidElement(current)) {
+      current = {props: current, ref: current.ref};
+    }
+
     if (process.env.NODE_ENV !== "production") {
       invariant(
-        current.handler !== undefined && current.path !== undefined,
+        current.props.handler !== undefined && current.props.path !== undefined,
         "Router should contain either Route or NotFound components " +
         "as routes")
     }
 
-    if (current.path) {
-      current.pattern = current.pattern || pattern.newPattern(current.path);
+    if (current.props.path) {
+      current.props.pattern = current.props.pattern || pattern.newPattern(current.props.path);
       if (!page) {
-        match = current.pattern.match(path);
+        match = current.props.pattern.match(path);
         if (match) {
           page = current;
         }
@@ -42,7 +49,7 @@ function matchRoutes(routes, path) {
         }
       }
     }
-    if (!notFound && current.path === null) {
+    if (!notFound && current.props.path === null) {
       notFound = current;
     }
   }
@@ -74,16 +81,12 @@ function Match(path, route, match) {
 }
 
 Match.prototype.getHandler = function() {
-  var props = {};
-  if (this.match) {
-    mergeInto(props, this.match);
-  }
-  if (this.route && this.route.props) {
-    mergeInto(props, this.route.props);
-  }
-  // we will set ref later during a render call
-  delete props.ref;
-  return this.route ? this.route.handler(props) : undefined;
+  if (!this.route) return undefined;
+  var props = assign({}, this.route.props, this.match);
+  delete props.pattern;
+  delete props.path;
+  delete props.handler;
+  return this.route.props.handler(props);
 }
 
 module.exports = matchRoutes;

--- a/lib/matchRoutes.js
+++ b/lib/matchRoutes.js
@@ -82,11 +82,14 @@ function Match(path, route, match) {
 
 Match.prototype.getHandler = function() {
   if (!this.route) return undefined;
+  var factory = React.createFactory(this.route.props.handler);
   var props = assign({}, this.route.props, this.match);
+
   delete props.pattern;
   delete props.path;
   delete props.handler;
-  return this.route.props.handler(props);
+
+  return factory(props);
 }
 
 module.exports = matchRoutes;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "browserify": "^3.32.1",
     "browserify-shim": "^3.3.1",
-    "jshint": "~2.4.3",
+    "jsxhint": "~0.5.0",
     "mocha": "~1.17.1",
     "react-tools": "^0.12.0",
     "reactify": "^0.15.1",

--- a/package.json
+++ b/package.json
@@ -5,25 +5,22 @@
   "main": "index.js",
   "dependencies": {
     "envify": "^1.2.1",
-    "react": "^0.11.1",
+    "object.assign": "^1.0.1",
+    "react": "^0.12.0",
+    "react-async": "~2.0.0",
     "url-pattern": "~0.6.0",
     "urllite": "~0.4.0"
   },
-  "peerDependencies": {
-    "react": "~0.11.0",
-    "react-async": "~1.0.1"
-  },
   "devDependencies": {
-    "react": "~0.11.0",
-    "react-async": "~1.0.1",
-    "semver": "~2.2.1",
-    "mocha": "~1.17.1",
-    "jshint": "~2.4.3",
-    "zuul": "~1.5.2",
-    "browserify-shim": "^3.3.1",
-    "uglify-js": "^2.4.13",
     "browserify": "^3.32.1",
-    "reactify": "^0.14.0"
+    "browserify-shim": "^3.3.1",
+    "jshint": "~2.4.3",
+    "mocha": "~1.17.1",
+    "react-tools": "^0.12.0",
+    "reactify": "^0.15.1",
+    "semver": "~2.2.1",
+    "uglify-js": "^2.4.13",
+    "zuul": "~1.5.2"
   },
   "browserify": {
     "transform": [

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -1,0 +1,27 @@
+{
+  "undef": true,
+  "unused": "vars",
+  "asi": true,
+  "expr": true,
+  "globalstrict": true,
+  "es3": true,
+  "newcap": false,
+  "globals": {
+    "window": false,
+    "Buffer": false,
+    "require": false,
+    "process": false,
+    "module": false,
+    "exports": false,
+    "console": false,
+    "document": false,
+    "setTimeout": false,
+    /* MOCHA */
+    "describe"   : false,
+    "it"         : false,
+    "before"     : false,
+    "beforeEach" : false,
+    "after"      : false,
+    "afterEach"  : false
+  }
+}

--- a/tests/QueryStringKeyEnvironment.js
+++ b/tests/QueryStringKeyEnvironment.js
@@ -17,7 +17,7 @@ describe('QuerystringKeyEnvironment', function() {
 
   it('updates the corresponding key in querystring on setPath', function() {
     env.setPath('/x', {});
-    assert.equal(location.search, '?key=x');
+    assert.equal(window.location.search, '?key=x');
   });
 
   it('returns a corresponding key from querystring via getPath', function() {

--- a/tests/browser-jsx.js
+++ b/tests/browser-jsx.js
@@ -1,0 +1,111 @@
+'use strict';
+var assert          = require('assert');
+var React           = require('react');
+var Router          = require('../index');
+
+var historyAPI = (
+    window.history !== undefined &&
+    window.history.pushState !== undefined
+);
+
+var host, app, router;
+
+var timeout = 250;
+
+function delay(ms, func) {
+  if (func === undefined) {
+    func = ms;
+    ms = timeout;
+  }
+  setTimeout(func, ms);
+}
+
+function getRenderedContent() {
+  var content = app.refs.content || app.refs.router;
+  var node = content.getDOMNode();
+  return node.textContent || node.innerText;
+}
+
+function assertRendered(text) {
+  assert.equal(
+    getRenderedContent(),
+    text
+  );
+}
+
+function cleanUp(done) {
+  React.unmountComponentAtNode(host);
+  if (historyAPI) {
+    window.history.pushState({}, '', '/__zuul');
+  }
+  window.location.hash = '';
+  delay(done);
+}
+
+function setUp(App) {
+  return function() {
+    host = document.createElement('div');
+    app = React.render(React.createElement(App), host);
+    router = app.refs.router;
+  }
+}
+describe('JSX + Routing with async components', function() {
+
+  if (!historyAPI) return;
+
+  var App = React.createClass({displayName: 'App',
+
+    render: function() {
+      var Locations = Router.Locations;
+      var Location = Router.Location;
+      return (
+        React.createElement(Locations, {ref: "router", className: "App"}, 
+          React.createElement(Location, {path: "/__zuul", handler: Main, ref: "main"}), 
+          React.createElement(Location, {path: "/__zuul/page1", handler: Page1, ref: "page1"}), 
+          React.createElement(Location, {path: "/__zuul/:text", handler: Page2, ref: "page2"})
+        )
+      );
+    }
+  });
+
+  var Main = React.createClass({displayName: 'Main',
+    render: function() {
+      return React.createElement("div", null, "Main");
+    }
+  });
+
+  var Page1 = React.createClass({displayName: 'Page1',
+    render: function() {
+      return React.createElement("div", null, "Page1")
+    }
+  });
+
+  var Page2 = React.createClass({displayName: 'Page2',
+    render: function() {
+      return React.createElement("div", null, this.props.text)
+    }
+  });
+
+  beforeEach(setUp(App));
+  afterEach(cleanUp);
+
+  it('jsx: renders component', function() {
+    assertRendered('Main');
+  });
+
+  it('jsx: renders another route', function(done) {
+    router.navigate('/__zuul/page1', function(err) {
+      if (err) return done(err);
+      assertRendered('Page1');
+      done();
+    });
+  });
+
+  it('jsx: renders a route with params', function(done) {
+    router.navigate('/__zuul/page2', function(err) {
+      if (err) return done(err);
+      assertRendered('page2');
+      done();
+    });
+  });
+});

--- a/tests/browser.js
+++ b/tests/browser.js
@@ -5,7 +5,11 @@ var React           = require('react');
 var ReactTestUtils  = require('react/lib/ReactTestUtils');
 var EventConstants  = require('react/lib/EventConstants');
 var Router          = require('../index');
-var CaptureClicks   = require('../lib/CaptureClicks');
+var CaptureClicks   = React.createFactory(require('../lib/CaptureClicks'));
+var Location        = React.createFactory(Router.Location);
+var Locations       = React.createFactory(Router.Locations);
+var NotFound        = React.createFactory(Router.NotFound);
+var Link            = React.createFactory(Router.Link);
 
 var historyAPI = (
     window.history !== undefined &&
@@ -59,7 +63,7 @@ function cleanUp(done) {
 function setUp(App) {
   return function() {
     host = document.createElement('div');
-    app = React.renderComponent(App(), host);
+    app = React.render(React.createElement(App), host);
     router = app.refs.router;
   }
 }
@@ -72,31 +76,32 @@ describe('Routing', function() {
 
     render: function() {
       return div({onClick: this.props.onClick},
-        Router.Locations({
+        Locations({
             ref: 'router', className: 'App',
             onNavigation: this.props.navigationHandler,
             onBeforeNavigation: this.props.beforeNavigationHandler
           },
-          Router.Location({
+          Location({
             path: '/__zuul',
             foo: 'bar',
             ref: 'link',
             handler: function(props) {
-              return Router.Link({
+              return Link({
                 foo: props.foo,
-                href: '/__zuul/hello',
+                ref: props.ref,
+                href: '/__zuul/hello'
               }, 'mainpage')
             }
           }),
-          Router.Location({
+          Location({
             path: '/__zuul/transient',
             handler: function(props) { return div(null, "i'm transient") }
           }),
-          Router.Location({
+          Location({
             path: '/__zuul/:slug',
             handler: function(props) { return div(null, props.slug) }
           }),
-          Router.NotFound({
+          NotFound({
             handler: function(props) { return div(null, 'not_found') }
           })
         ),
@@ -105,8 +110,8 @@ describe('Routing', function() {
           a({ref: 'anchorUnhandled', href: '/goodbye'}),
           a({ref: 'anchorExternal', href: 'https://github.com/andreypopp/react-router-component'})
         ),
-        Router.Link({ref: 'outside', href: '/__zuul/hi'}),
-        Router.Link({ref: 'prevented', href: '/__zuul/hi', onClick: this.handlePreventedLinkClick})
+        Link({ref: 'outside', href: '/__zuul/hi'}),
+        Link({ref: 'prevented', href: '/__zuul/hi', onClick: this.handlePreventedLinkClick})
       );
     },
 
@@ -297,10 +302,10 @@ describe('Routing with async components', function() {
   var App = React.createClass({
 
     render: function() {
-      return Router.Locations({ref: 'router', className: 'App'},
-        Router.Location({path: '/__zuul', handler: Main, ref: 'main'}),
-        Router.Location({path: '/__zuul/about', handler: About, ref: 'about'}),
-        Router.Location({path: '/__zuul/about2', handler: About, ref: 'about2'})
+      return Locations({ref: 'router', className: 'App'},
+        Location({path: '/__zuul', handler: Main, ref: 'main'}),
+        Location({path: '/__zuul/about', handler: About, ref: 'about'}),
+        Location({path: '/__zuul/about2', handler: About, ref: 'about2'})
       );
     }
   });
@@ -326,6 +331,7 @@ describe('Routing with async components', function() {
       return div(null, this.state.message ? this.state.message : 'loading...');
     }
   });
+  Main = React.createFactory(Main);
 
   var About = React.createClass({
     mixins: [ReactAsync.Mixin],
@@ -344,6 +350,7 @@ describe('Routing with async components', function() {
       return div(null, this.state.message ? this.state.message : 'loading...');
     }
   });
+  About = React.createFactory(About);
 
   beforeEach(function() {
     mainWasInLoadingState = false; 
@@ -448,14 +455,14 @@ describe('Nested routers', function() {
   var NestedRouter = React.createClass({
     render: function() {
       return div(null,
-        Router.Locations(null,
-          Router.Location({
+        Locations(null,
+          Location({
             path: '/__zuul/nested/',
             handler: function(props) {
               return div(null, 'nested/root');
             }
           }),
-          Router.Location({
+          Location({
             path: '/__zuul/nested/page',
             handler: function(props) {
               return div(null, 'nested/page');
@@ -469,16 +476,16 @@ describe('Nested routers', function() {
 
     render: function() {
       return div(null,
-        Router.Locations({ref: 'router', className: 'App'},
-          Router.Location({
+        Locations({ref: 'router', className: 'App'},
+          Location({
             path: '/__zuul',
             foo: 'bar',
             ref: 'link',
             handler: function(props) {
-              return Router.Link({foo: props.foo, href: '/__zuul/hello'}, 'mainpage')
+              return Link({foo: props.foo, href: '/__zuul/hello'}, 'mainpage')
             }
           }),
-          Router.Location({
+          Location({
             path: '/__zuul/nested/*',
             handler: NestedRouter
           })
@@ -558,23 +565,23 @@ describe('Contextual routers', function() {
 
     render: function() {
       return div(null,
-        Router.Locations({ref: 'router', contextual: true},
-          Router.Location({
+        Locations({ref: 'router', contextual: true},
+          Location({
             path: '/',
             handler: function(props) { return div(null, 'subcat/root') }
           }),
-          Router.Location({
+          Location({
             path: '/page',
             ref: 'link',
             handler: function(props) {
-              return Router.Link({href: '/'}, 'subcat/page')
+              return Link({href: '/'}, 'subcat/page')
             }
           }),
-          Router.Location({
+          Location({
             path: '/escape',
             ref: 'link',
             handler: function(props) {
-              return Router.Link({global: true, href: '/__zuul'}, 'subcat/escape')
+              return Link({global: true, href: '/__zuul'}, 'subcat/escape')
             }
           })
         ));
@@ -584,14 +591,14 @@ describe('Contextual routers', function() {
   var App = React.createClass({
 
     render: function() {
-      return Router.Locations({ref: 'router'},
-        Router.Location({
+      return Locations({ref: 'router'},
+        Location({
           path: '/__zuul',
           handler: function() {
             return div(null, "mainpage")
           }
         }),
-        Router.Location({
+        Location({
           path: '/__zuul/subcat/*',
           handler: SubCat,
           ref: 'subcat'
@@ -662,15 +669,15 @@ describe('Multiple active routers', function() {
   var App = React.createClass({
 
     render: function() {
-      var router1 = Router.Locations({ref: 'router1', className: 'App'},
-        Router.Location({
+      var router1 = Locations({ref: 'router1', className: 'App'},
+        Location({
           path: '/__zuul',
           ref: 'link',
           handler: function(props) {
-            return Router.Link({href: '/__zuul/hello'}, 'mainpage1')
+            return Link({href: '/__zuul/hello'}, 'mainpage1')
           }
         }),
-        Router.Location({
+        Location({
           path: '/__zuul/:slug',
           handler: function(props) {
             return div(null, props.slug + '1');
@@ -678,15 +685,15 @@ describe('Multiple active routers', function() {
         })
       );
 
-      var router2 = Router.Locations({ref: 'router2', className: 'App'},
-        Router.Location({
+      var router2 = Locations({ref: 'router2', className: 'App'},
+        Location({
           path: '/__zuul',
           ref: 'link',
           handler: function(props) {
-            return Router.Link({href: '/__zuul/hello'}, 'mainpage2')
+            return Link({href: '/__zuul/hello'}, 'mainpage2')
           }
         }),
-        Router.Location({
+        Location({
           path: '/__zuul/:slug',
           handler: function(props) {
             return div(null, props.slug + '2');
@@ -739,21 +746,21 @@ describe('Hash routing', function() {
   var App = React.createClass({
 
     render: function() {
-      return Router.Locations({ref: 'router', hash: true, className: 'App'},
-        Router.Location({
+      return Locations({ref: 'router', hash: true, className: 'App'},
+        Location({
           path: '/',
           ref: 'link',
           handler: function(props) {
-            return Router.Link({href: '/hello'}, 'mainpage');
+            return Link({href: '/hello'}, 'mainpage');
           }
         }),
-        Router.Location({
+        Location({
           path: '/transient',
           handler: function(props) {
             return div(null, "i'm transient");
           }
         }),
-        Router.Location({
+        Location({
           path: '/:slug',
           handler: function(props) {
             return div(null, props.slug);
@@ -838,16 +845,16 @@ describe('Contextual Hash routers', function() {
 
     render: function() {
       return div(null,
-        Router.Locations({ref: 'router', contextual: true},
-          Router.Location({
+        Locations({ref: 'router', contextual: true},
+          Location({
             path: '/',
             handler: function(props) { return div(null, 'subcat/root') }
           }),
-          Router.Location({
+          Location({
             path: '/escape',
             ref: 'link',
             handler: function(props) {
-              return Router.Link({globalHash: true, href: '/'}, 'subcat/escape');
+              return Link({globalHash: true, href: '/'}, 'subcat/escape');
             }
           })
         ));
@@ -857,14 +864,14 @@ describe('Contextual Hash routers', function() {
   var App = React.createClass({
 
     render: function() {
-      return Router.Locations({ref: 'router', hash: true},
-        Router.Location({
+      return Locations({ref: 'router', hash: true},
+        Location({
           path: '/',
           handler: function() {
             return div(null, "mainpage");
           }
         }),
-        Router.Location({
+        Location({
           path: '/subcat/*',
           handler: SubCat,
           ref: 'subcat'

--- a/tests/browser.js
+++ b/tests/browser.js
@@ -159,7 +159,7 @@ describe('Routing', function() {
     assertRendered('mainpage');
     router.navigate('/__zuul/hello', function() {
       assertRendered('hello');
-      history.back();
+      window.history.back();
       delay(function() {
         assertRendered('mainpage');
         done();
@@ -173,7 +173,7 @@ describe('Routing', function() {
       assertRendered('hello');
       router.navigate('/__zuul/transient', {replace: true}, function() {
         assertRendered("i'm transient");
-        history.back();
+        window.history.back();
         delay(function() {
           assertRendered('mainpage');
           done();
@@ -787,7 +787,7 @@ describe('Hash routing', function() {
       delay(function() {
         router.navigate('/transient', {replace: true}, function() {
           assertRendered("i'm transient");
-          history.back();
+          window.history.back();
           delay(function() {
             assertRendered('mainpage');
             done();
@@ -898,5 +898,5 @@ describe('Contextual Hash routers', function() {
     });
 
   });
-
 });
+

--- a/tests/matchRoutes.js
+++ b/tests/matchRoutes.js
@@ -1,25 +1,28 @@
 'use strict';
-var assert          = require('assert');
-var matchRoutes     = require('../lib/matchRoutes');
+var assert      = require('assert');
+var matchRoutes = require('../lib/matchRoutes');
+var React       = require('react');
+var Router      = require('../');
+var Location       = React.createFactory(Router.Location);
+var NotFound    = React.createFactory(Router.NotFound);
 
 describe('matchRoutes', function() {
 
   function handler(props) {
-    return props;
+    return React.DOM.div(props);
   }
-
   var routes = [
-    {path: '(/)', handler: handler({name: 'root'})},
-    {path: '/cat/:id', handler: handler({name: 'cat'})},
-    {path: '/mod/*', handler: handler({name: 'mod'})},
-    {path: /\/regex\/([a-zA-Z]*)$/, handler: handler({name: 'regex'})},
-    {path: null, handler: handler({name: 'notfound'})}
+    Location({path: '(/)', handler: handler({name: 'root'})}),
+    Location({path: '/cat/:id', handler: handler({name: 'cat'})}),
+    Location({path: '/mod/*', handler: handler({name: 'mod'})}),
+    Location({path: /\/regex\/([a-zA-Z]*)$/, handler: handler({name: 'regex'})}),
+    NotFound({handler: handler({name: 'notfound'})})
   ];
 
   it('matches ""', function() {
     var match = matchRoutes(routes, '');
     assert(match.route);
-    assert.strictEqual(match.route.handler.name, 'root');
+    assert.strictEqual(match.route.props.handler.props.name, 'root');
     assert.deepEqual(match.match, {});
     assert.strictEqual(match.path, '');
     assert.strictEqual(match.matchedPath, '');
@@ -29,7 +32,7 @@ describe('matchRoutes', function() {
   it('matches /', function() {
     var match = matchRoutes(routes, '/');
     assert(match.route);
-    assert.strictEqual(match.route.handler.name, 'root');
+    assert.strictEqual(match.route.props.handler.props.name, 'root');
     assert.deepEqual(match.match, {});
     assert.strictEqual(match.path, '/');
     assert.strictEqual(match.matchedPath, '/');
@@ -39,7 +42,7 @@ describe('matchRoutes', function() {
   it('matches /cat/:id', function() {
     var match = matchRoutes(routes, '/cat/hello');
     assert(match.route);
-    assert.strictEqual(match.route.handler.name, 'cat');
+    assert.strictEqual(match.route.props.handler.props.name, 'cat');
     assert.deepEqual(match.match, {id: 'hello'});
     assert.strictEqual(match.path, '/cat/hello');
     assert.strictEqual(match.matchedPath, '/cat/hello');
@@ -49,7 +52,7 @@ describe('matchRoutes', function() {
   it('matches /mod/wow/here', function() {
     var match = matchRoutes(routes, '/mod/wow/here');
     assert(match.route);
-    assert.strictEqual(match.route.handler.name, 'mod');
+    assert.strictEqual(match.route.props.handler.props.name, 'mod');
     assert.deepEqual(match.match, {_: ['wow/here']});
     assert.strictEqual(match.path, '/mod/wow/here');
     assert.strictEqual(match.matchedPath, '/mod/');
@@ -59,7 +62,7 @@ describe('matchRoutes', function() {
   it('matches /regex/text', function() {
     var match = matchRoutes(routes, '/regex/text');
     assert(match.route);
-    assert.strictEqual(match.route.handler.name, 'regex');
+    assert.strictEqual(match.route.props.handler.props.name, 'regex');
     assert.deepEqual(match.match, {_: ['text']});
     assert.strictEqual(match.path, '/regex/text');
     assert.strictEqual(match.matchedPath, '/regex/');
@@ -69,7 +72,7 @@ describe('matchRoutes', function() {
   it('does not match /regex/1text', function() {
     var match = matchRoutes(routes, '/regex/1text');
     assert(match.route);
-    assert.strictEqual(match.route.handler.name, 'notfound');
+    assert.strictEqual(match.route.props.handler.props.name, 'notfound');
     assert.deepEqual(match.match, null);
     assert.strictEqual(match.path, '/regex/1text');
     assert.strictEqual(match.matchedPath, '/regex/1text');
@@ -79,7 +82,7 @@ describe('matchRoutes', function() {
   it('handles not found', function() {
     var match = matchRoutes(routes, '/hm');
     assert(match.route);
-    assert.strictEqual(match.route.handler.name, 'notfound');
+    assert.strictEqual(match.route.props.handler.props.name, 'notfound');
     assert.deepEqual(match.match, null);
     assert.strictEqual(match.path, '/hm');
     assert.strictEqual(match.matchedPath, '/hm');

--- a/tests/server.js
+++ b/tests/server.js
@@ -1,53 +1,60 @@
 'use strict';
-var assert = require('assert');
-var React  = require('react');
-var Router = require('../index');
+var assert    = require('assert');
+var React     = require('react');
+var Router    = require('../index');
+var Location  = React.createFactory(Router.Location);
+var Locations = React.createFactory(Router.Locations);
+var Pages     = React.createFactory(Router.Pages);
+var NotFound  = React.createFactory(Router.NotFound);
+var Link      = React.createFactory(Router.Link);
 
 describe('react-router-component (on server)', function() {
 
   var App = React.createClass({
 
     render: function() {
-      return Router.Locations({className: 'App', path: this.props.path},
-        Router.Location({
+      return Locations({className: 'App', path: this.props.path},
+        Location({
           path: '/',
           handler: function(props) { return React.DOM.div(null, 'mainpage'); }
         }),
-        Router.Location({
+        Location({
           path: '/x/:slug',
           handler: function(props) { return React.DOM.div(null, props.slug); }
         }),
-        Router.Location({
+        Location({
           path: /\/y(.*)/,
           handler: function(props) { return React.DOM.div(null, props._[0]);}
         }),
-        Router.NotFound({
+        NotFound({
           handler: function(props) { return React.DOM.div(null, 'not_found'); }
         })
       );
     }
   });
 
+  App = React.createFactory(App);
+
   it('renders to /', function() {
-    var markup = React.renderComponentToString(App({path: '/'}));
+    var markup = React.renderToString(App({path: '/'}));
     assert(markup.match(/class="App"/));
     assert(markup.match(/mainpage/));
   });
 
   it('renders to /:slug', function() {
-    var markup = React.renderComponentToString(App({path: '/x/hello'}));
+    var markup = React.renderToString(App({path: '/x/hello'}));
     assert(markup.match(/class="App"/));
     assert(markup.match(/hello/));
   });
 
   it('renders with regex', function() {
-    var markup = React.renderComponentToString(App({path: '/y/ohhai'}));
+    var markup = React.renderToString(App({path: '/y/ohhai'}));
     assert(markup.match(/class="App"/));
     assert(markup.match(/ohhai/));
   })
 
   it('renders to empty on notfound', function() {
-    var markup = React.renderComponentToString(App({path: '/notfound'}));
+    var markup = React.renderToString(App({path: '/notfound'}));
     assert(markup.match(/class="App"/));
     assert(markup.match(/not_found/));
   });
@@ -57,8 +64,8 @@ describe('react-router-component (on server)', function() {
     var App = React.createClass({
 
       render: function() {
-        return Router.Pages({className: 'App', path: this.props.path},
-          Router.Location({
+        return Pages({className: 'App', path: this.props.path},
+          Location({
             path: '/',
             handler: function(props) { return React.DOM.div(null, 'mainpage') }
           })
@@ -66,8 +73,9 @@ describe('react-router-component (on server)', function() {
       }
     });
 
+
     it('renders to <body>', function() {
-      var markup = React.renderComponentToString(App({path: '/'}));
+      var markup = React.renderToString(React.createElement(App, {path: '/'}));
       assert(markup.match(/<body [^>]+><div [^>]+>mainpage<\/div><\/body>/));
     });
 
@@ -78,27 +86,27 @@ describe('react-router-component (on server)', function() {
     var ContextualRouter = React.createClass({
 
       render: function() {
-        return Router.Locations({className: 'X', contextual: true},
-          Router.Location({
+        return Locations({className: 'X', contextual: true},
+          Location({
             path: '/hello',
             handler: function(props) {
-              return Router.Link({href: '/hi'});
+              return Link({href: '/hi'});
             }
           }),
-          Router.Location({
+          Location({
             path: '/hello2',
             handler: function(props) {
-              return Router.Link({global: true, href: '/hi'});
+              return Link({global: true, href: '/hi'});
             }
            }),
-           Router.Location({
+           Location({
             path: '/hello3/*',
             handler: function(props) {
-              return Router.Locations({className: 'Y', contextual: true},
-                Router.Location({
+              return Locations({className: 'Y', contextual: true},
+                Location({
                   path: '/:subslug',
                   handler: function(props) {
-                    return Router.Link({href: '/sup-' + props.subslug});
+                    return Link({href: '/sup-' + props.subslug});
                   }
                 })
               );
@@ -111,8 +119,8 @@ describe('react-router-component (on server)', function() {
     var App = React.createClass({
 
       render: function() {
-        return Router.Locations({className: 'App', path: this.props.path},
-          Router.Location({
+        return Locations({className: 'App', path: this.props.path},
+          Location({
             path: '/x/:slug/*',
             handler: ContextualRouter
           })
@@ -120,22 +128,24 @@ describe('react-router-component (on server)', function() {
       }
     });
 
+    App = React.createFactory(App);
+
     it ('renders Link component with href scoped to its prefix', function() {
-      var markup = React.renderComponentToString(App({path: '/x/nice/hello'}));
+      var markup = React.renderToString(App({path: '/x/nice/hello'}));
       assert(markup.match(/class="App"/));
       assert(markup.match(/class="X"/));
       assert(markup.match(/href="\/x\/nice\/hi"/));
     });
 
     it ('renders global Link component with correct href (not scoped to a router)', function() {
-      var markup = React.renderComponentToString(App({path: '/x/nice/hello2'}));
+      var markup = React.renderToString(App({path: '/x/nice/hello2'}));
       assert(markup.match(/class="App"/));
       assert(markup.match(/class="X"/));
       assert(markup.match(/href="\/hi"/));
     });
 
     it ('renders Link component with href scoped to its nested context prefix', function() {
-      var markup = React.renderComponentToString(App({path: '/x/nice/hello3/welcome'}));
+      var markup = React.renderToString(App({path: '/x/nice/hello3/welcome'}));
       assert(markup.match(/class="App"/));      
       assert(markup.match(/class="X"/));
       assert(markup.match(/class="Y"/));
@@ -151,17 +161,17 @@ describe('react-router-component (on server)', function() {
 
       render: function() {
         var thisSlug = this.props.slug;
-        return Router.Locations({className: 'L2', contextual: true},
-          Router.Location({
+        return Locations({className: 'L2', contextual: true},
+          Location({
             path: '/',
             handler: function(props) {
-              return Router.Link({href: '/hello', 'data-slug': thisSlug});
+              return Link({href: '/hello', 'data-slug': thisSlug});
             }
           }),
-          Router.Location({
+          Location({
             path: '/:slug',
             handler: function(props) {
-              return Router.Link({global: true, href: '/hi', 'data-slug': props.slug});
+              return Link({global: true, href: '/hi', 'data-slug': props.slug});
             }
           })
         )
@@ -172,14 +182,14 @@ describe('react-router-component (on server)', function() {
 
       render: function() {
         var thisSlug = this.props.slug;
-        return Router.Locations({className: 'L1', contextual: true},
-          Router.Location({
+        return Locations({className: 'L1', contextual: true},
+          Location({
             path: '/',
             handler: function(props) {
-              return Router.Link({href: '/l2', 'data-slug': thisSlug});
+              return Link({href: '/l2', 'data-slug': thisSlug});
             }
           }),
-          Router.Location({
+          Location({
             path: '/:slug(/*)',
             handler: Level2
           })
@@ -190,8 +200,8 @@ describe('react-router-component (on server)', function() {
     var App = React.createClass({
 
       render: function() {
-        return Router.Locations({className: 'App', path: this.props.path},
-          Router.Location({
+        return Locations({className: 'App', path: this.props.path},
+          Location({
             path: '/l1/:slug(/*)',
             handler: Level1
           })
@@ -200,7 +210,7 @@ describe('react-router-component (on server)', function() {
     });
 
     it ('renders Link component with href scoped to its prefix', function() {
-      var markup = React.renderComponentToString(App({path: '/l1/nice'}));
+      var markup = React.renderToString(App({path: '/l1/nice'}));
       assert(markup.match(/class="App"/));
       assert(markup.match(/class="L1"/));
       assert(markup.match(/href="\/l1\/nice\/l2"/));
@@ -208,7 +218,7 @@ describe('react-router-component (on server)', function() {
     });
 
     it ('renders Link component with href scoped to its prefix - trailing slash', function() {
-      var markup = React.renderComponentToString(App({path: '/l1/nice/'}));
+      var markup = React.renderToString(App({path: '/l1/nice/'}));
       assert(markup.match(/class="App"/));
       assert(markup.match(/class="L1"/));
       assert(markup.match(/href="\/l1\/nice\/l2"/));
@@ -216,7 +226,7 @@ describe('react-router-component (on server)', function() {
     });
 
     it ('renders nested Link component with href scoped to its prefix', function() {
-      var markup = React.renderComponentToString(App({path: '/l1/nice/l2'}));
+      var markup = React.renderToString(App({path: '/l1/nice/l2'}));
       assert(markup.match(/class="App"/));
       assert(markup.match(/class="L1"/));
       assert(markup.match(/class="L2"/));
@@ -225,7 +235,7 @@ describe('react-router-component (on server)', function() {
     });
 
     it ('renders global Link component with correct href (not scoped to a router)', function() {
-      var markup = React.renderComponentToString(App({path: '/l1/nice/l2/foo'}));
+      var markup = React.renderToString(App({path: '/l1/nice/l2/foo'}));
       assert(markup.match(/class="App"/));
       assert(markup.match(/class="L2"/));
       assert(markup.match(/href="\/hi"/));
@@ -238,8 +248,8 @@ describe('react-router-component (on server)', function() {
     var App = React.createClass({
 
       render: function() {
-        return Router.Locations({className: 'App', path: this.props.path},
-          Router.Location({
+        return Locations({className: 'App', path: this.props.path},
+          Location({
             path: '/',
             handler: function(props) { return React.DOM.div(null, 'mainpage') }
           })
@@ -248,7 +258,7 @@ describe('react-router-component (on server)', function() {
     });
 
     it('renders to /', function() {
-      var markup = React.renderComponentToString(App({path: '/'}));
+      var markup = React.renderToString(App({path: '/'}));
       assert(markup.match(/class="App"/));
       assert(markup.match(/mainpage/));
     });

--- a/tests/server.js
+++ b/tests/server.js
@@ -209,6 +209,8 @@ describe('react-router-component (on server)', function() {
       }
     });
 
+    App = React.createFactory(App);
+
     it ('renders Link component with href scoped to its prefix', function() {
       var markup = React.renderToString(App({path: '/l1/nice'}));
       assert(markup.match(/class="App"/));
@@ -256,6 +258,8 @@ describe('react-router-component (on server)', function() {
         );
       }
     });
+
+    App = React.createFactory(App);
 
     it('renders to /', function() {
       var markup = React.renderToString(App({path: '/'}));


### PR DESCRIPTION
  React 0.12 depreciated directly invoking components, they now need to be wrapped in a React.createFactory call. We now do this for the handlers passed in to the router in order to suppress the warning.