### PR TITLE
Fixed invariant issue when using routers as root element in react classes

### DIFF
--- a/lib/Router.js
+++ b/lib/Router.js
@@ -22,15 +22,9 @@ function createRouter(name, component) {
       return props.children;
     },
 
-    getDefaultProps: function() {
-      return {
-        component: component
-      }
-    },
-
     render: function() {
       var handler = this.renderRouteHandler();
-      return this.transferPropsTo(this.props.component(null, handler));
+      return this.transferPropsTo(component(null, handler));
     }
   });
 }


### PR DESCRIPTION
Because of the way React does props, it seems like using "this.props.component" is not entirely the best solution for passing in the props.

Luckily, with the way that @STRML structured the function, `component` is scoped in a way that it can be used instead. There's no need for `getDefaultProps` or to use `this.props.component` in this situation.

By using the actual component, rather than using `this.props.component`, we're able to get rid of the invariant issue (see https://github.com/STRML/react-router-component/issues/102 for more details on the issue).
