### PR TITLE
Bypass router on external/full url links

### DIFF
--- a/lib/Link.js
+++ b/lib/Link.js
@@ -24,6 +24,11 @@ var Link = React.createClass({
   },
 
   onClick: function(e) {
+    if (this.props.href.search(/^http/i) > -1) {
+      window.location.href = this.props.href;
+      return false;
+    }
+
     if (this.props.onClick) {
       this.props.onClick(e);
     }

--- a/lib/Link.js
+++ b/lib/Link.js
@@ -25,8 +25,7 @@ var Link = React.createClass({
 
   onClick: function(e) {
     if (this.props.href.search(/^http/i) > -1) {
-      window.location.href = this.props.href;
-      return false;
+      return true;
     }
 
     if (this.props.onClick) {

--- a/lib/RouterMixin.js
+++ b/lib/RouterMixin.js
@@ -203,7 +203,12 @@ var RouterMixin = {
 };
 
 function join(a, b) {
-  return (a + b).replace(/\/\//g, '/');
+  if ((a+b).search(/^http/i) > -1) {
+    return (a + b);
+  }
+  else {
+    return (a + b).replace(/\/\//g, '/');
+  }
 }
 
 function isString(o) {

--- a/lib/RouterMixin.js
+++ b/lib/RouterMixin.js
@@ -203,7 +203,9 @@ var RouterMixin = {
 };
 
 function join(a, b) {
-  if ((a+b).search(/^http/i) > -1) {
+  // Do not replace // with / when the url begins with `http`
+  // Covers the http:// and https:// cases.
+  if ((a + b).search(/^http/i) > -1) {
     return (a + b);
   }
   else {

--- a/tests/browser.js
+++ b/tests/browser.js
@@ -123,6 +123,7 @@ describe('Routing', function() {
           a({ref: 'anchorUnhandled', href: '/goodbye'}),
           a({ref: 'anchorExternal', href: 'https://github.com/andreypopp/react-router-component'})
         ),
+        Link({ref: 'externalUrl', rel: '_external', href: 'http://github.com'}),
         Link({ref: 'outside', href: '/__zuul/hi'}),
         Link({ref: 'prevented', href: '/__zuul/hi', onClick: this.handlePreventedLinkClick})
       );
@@ -241,6 +242,17 @@ describe('Routing', function() {
       clickOn(router.refs.link);
       delay(function() {
         assertRendered('hello');
+        done();
+      });
+    });
+
+     it('navigates to external Urls', function(done) {
+      assertRendered('mainpage');
+      clickOn(app.refs.externalUrl);
+      delay(function() {
+        // Not sure how to vefify this case and continue.
+        // Browser gets redirected to external.
+        assertRendered('github.com page opened');
         done();
       });
     });


### PR DESCRIPTION
(1) fix makeHref which originally would modify url as such join("", "http://example.com”) —> http:/example.com
(2) if a url starts with `http`, send client to that external site