### PR TITLE
PathnameEnvironment usable in non-html5 history api browser; falls back on window.location.pathname

### DIFF
--- a/lib/environment/PathnameEnvironment.js
+++ b/lib/environment/PathnameEnvironment.js
@@ -7,6 +7,9 @@ var Environment = require('./Environment');
  */
 function PathnameEnvironment() {
   this.onPopState = this.onPopState.bind(this);
+  this.useHistoryApi = !!(window.history &&
+                          window.history.pushState &&
+                          window.history.replaceState);
   Environment.call(this);
 }
 
@@ -18,21 +21,29 @@ PathnameEnvironment.prototype.getPath = function() {
 }
 
 PathnameEnvironment.prototype.pushState = function(path, navigation) {
-  window.history.pushState({}, '', path);
+  if (this.useHistoryApi) {
+    window.history.pushState({}, '', path);
+  } else {
+    window.location.pathname = path;
+  }
 }
 
 PathnameEnvironment.prototype.replaceState = function(path, navigation) {
-  window.history.replaceState({}, '', path);
+  if (this.useHistoryApi) {
+    window.history.replaceState({}, '', path);
+  } else {
+    window.location.pathname = path;
+  }
 }
 
 PathnameEnvironment.prototype.start = function() {
-  if (window.addEventListener) {
+  if (this.useHistoryApi && window.addEventListener) {
     window.addEventListener('popstate', this.onPopState);
   }
 };
 
 PathnameEnvironment.prototype.stop = function() {
-  if (window.removeEventListener) {
+  if (this.useHistoryApi && window.removeEventListener) {
     window.removeEventListener('popstate', this.onPopState);
   }
 };


### PR DESCRIPTION
This is related to issue https://github.com/STRML/react-router-component/issues/110, though it is not a complete solution.  If you force the Environment to PathnameEnvironment but `window.history` isn't available, it will fall back on just setting `window.location.pathname`.  This allows old browsers like IE9 to use modern routes with minimal effort, gracefully falling back to a normal page reload when the history api isn't available.

Personally, I think this should be the default behavior unless `hash={true}` is specified, but that is up to the authors.  A change like that would also require thinking more about the relationship between pathname and hash routing, and the problems of sharing routes between both sides.  This is mentioned here as well: https://github.com/STRML/react-router-component/issues/99

This pull request should be safe for backwards compatibility, as it only changes behavior for people explicitly setting the environment to use to `PathnameEnvironment`, a case which prior to this pull request simply throws an exception in IE9.