### PR TITLE
Make localstorage env node safe

### DIFF
--- a/lib/environment/LocalStorageKeyEnvironment.js
+++ b/lib/environment/LocalStorageKeyEnvironment.js
@@ -7,15 +7,15 @@ var Environment = require('./Environment');
  */
 function LocalStorageKeyEnvironment(key) {
   this.key = key;
-  this.onStorage = this.onStorage.bind(this);
-  Environment.call(this);
+  var store = this.onStorage = this.onStorage.bind(this);
 
-  var store = this.onStorage;
   this.storage = (typeof window !== 'undefined' && window.localStorage) || {
     data: {},
     getItem: function(key) {return this.data[key];},
     setItem: function(key, val) {this.data[key]=val;store();}
   };
+
+  Environment.call(this);
 }
 
 LocalStorageKeyEnvironment.prototype = Object.create(Environment.prototype);

--- a/lib/environment/LocalStorageKeyEnvironment.js
+++ b/lib/environment/LocalStorageKeyEnvironment.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 var Environment = require('./Environment');
 
@@ -9,29 +9,40 @@ function LocalStorageKeyEnvironment(key) {
   this.key = key;
   this.onStorage = this.onStorage.bind(this);
   Environment.call(this);
+
+  var store = this.onStorage;
+  this.storage = (typeof window !== 'undefined' && window.localStorage) || {
+    data: {},
+    getItem: function(key) {return this.data[key];},
+    setItem: function(key, val) {this.data[key]=val;store();}
+  };
 }
 
 LocalStorageKeyEnvironment.prototype = Object.create(Environment.prototype);
 LocalStorageKeyEnvironment.prototype.constructor = LocalStorageKeyEnvironment;
 
 LocalStorageKeyEnvironment.prototype.getPath = function() {
-  return window.localStorage.getItem(this.key) || '';
+  return this.storage.getItem(this.key) || '';
 };
 
 LocalStorageKeyEnvironment.prototype.pushState = function(path, navigation) {
-  window.localStorage.setItem(this.key, path);
+  this.storage.setItem(this.key, path);
 };
 
 LocalStorageKeyEnvironment.prototype.replaceState = function(path, navigation) {
-  window.localStorage.setItem(this.key, path);
+  this.storage.setItem(this.key, path);
 };
 
 LocalStorageKeyEnvironment.prototype.start = function() {
-  window.addEventListener('storage', this.onStorage, false);
+  if (typeof window !== 'undefined' && window.addEventListener) {
+    window.addEventListener('storage', this.onStorage, false);
+  }
 };
 
 LocalStorageKeyEnvironment.prototype.stop = function() {
-  window.removeEventListener('storage', this.onStorage);
+  if (typeof window !== 'undefined' && window.removeEventListener) {
+    window.removeEventListener('storage', this.onStorage);
+  }
 };
 
 LocalStorageKeyEnvironment.prototype.onStorage = function() {


### PR DESCRIPTION
Recently realized using this environment when using server-side rendering blew things up. So, lets just make it safe for Node AND bonus: older browsers w/o LocalStorage.