### PR TITLE
Fixes onNavigation not being called when changing to identical route.

### DIFF
--- a/lib/environment/PathnameEnvironment.js
+++ b/lib/environment/PathnameEnvironment.js
@@ -51,9 +51,7 @@ PathnameEnvironment.prototype.stop = function() {
 PathnameEnvironment.prototype.onPopState = function(e) {
   var path = window.location.pathname;
 
-  if (this.path !== path) {
-    this.setPath(path, {isPopState: true});
-  }
+  this.setPath(path, {isPopState: true});
 };
 
 module.exports = PathnameEnvironment;


### PR DESCRIPTION
`onNavigation` should still be called even if you're navigating to an identical route because `react-router-component` does create an entry in its history for it.

I don't think it should just ignore it if they have the same path.