### PR TITLE
keep history state?

### DIFF
--- a/lib/environment/PathnameEnvironment.js
+++ b/lib/environment/PathnameEnvironment.js
@@ -22,7 +22,7 @@ PathnameEnvironment.prototype.getPath = function() {
 
 PathnameEnvironment.prototype.pushState = function(path, navigation) {
   if (this.useHistoryApi) {
-    window.history.pushState({}, '', path);
+    window.history.pushState(history.state || {}, '', path);
   } else {
     window.location.pathname = path;
   }
@@ -30,7 +30,7 @@ PathnameEnvironment.prototype.pushState = function(path, navigation) {
 
 PathnameEnvironment.prototype.replaceState = function(path, navigation) {
   if (this.useHistoryApi) {
-    window.history.replaceState({}, '', path);
+    window.history.replaceState(history.state || {}, '', path);
   } else {
     window.location.pathname = path;
   }


### PR DESCRIPTION
What do we think about this?  

Let's say you have a filter or a sort, something that doesn't quite belong on the url (because it's not important if it's not there) but it's nice if you hit the back/forward buttons if it remembered.

This is an idea, and looking for discussion.

Let's say you have your components that care about this, they have the `NavigatableMixin` and use the current route plus an identifier eg `/app/foo/::grid` as a key in the state and the value be whatever the component needs. `{sortOn: 'username', direction: 'ace'}` etc...
