### PR TITLE
NavigatableMixin.navigate: Add missing argument

### DIFF
--- a/lib/NavigatableMixin.js
+++ b/lib/NavigatableMixin.js
@@ -8,7 +8,7 @@ var Environment = require('./environment');
  * NavigatableMixin
  *
  * A mixin for a component which operates in context of a router and can
- * navigate to a different route using `navigate(path, cb)` method.
+ * navigate to a different route using `navigate(path, navigation, cb)` method.
  */
 var NavigatableMixin = {
 
@@ -27,8 +27,8 @@ var NavigatableMixin = {
     return this._getNavigable().getPath();
   },
 
-  navigate: function(path, cb) {
-    return this._getNavigable().navigate(path, cb);
+  navigate: function(path, navigation, cb) {
+    return this._getNavigable().navigate(path, navigation, cb);
   },
 
   makeHref: function(path) {


### PR DESCRIPTION
Environment.navigate takes 3 args: path, navigation, and cb.

NavigatableMixin.navigate, which calls Environment.navigate only accepted two arguments: path and cb. This change adds the missing argument.