### PR TITLE
`this` is not what you are looking for.

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ var CaptureClicks             = require('./lib/CaptureClicks');
 
 var URLPattern                = require('url-pattern');
 
-module.exports = {
+var exportsObject = {
   Locations: Router.Locations,
   Pages: Router.Pages,
 
@@ -42,6 +42,8 @@ module.exports = {
 
   // For ES6 imports, which can't modify module.exports directly
   setCreateURLPatternCompilerFactory: function(fn) {
-    this.createURLPatternCompiler = fn;
+    exportsObject.createURLPatternCompiler = fn;
   }
 };
+
+module.exports = exportsObject;


### PR DESCRIPTION
When invoked through ES6 module, either by:
```
import {setCreateURLPatternCompilerFactory} from 'react-router-component';
setCreateURLPatternCompilerFactory() // <-- this is undefined/null
```
or by
```
import * as Router from 'react-router-component';
Router.setCreateURLPatternCompilerFactory(); // <-- this is `Router` the local copy
```

this of the setter is not module.exports.