### PR TITLE
specify correct version support of querystring

### DIFF
--- a/docs/querystring.md
+++ b/docs/querystring.md
@@ -1,6 +1,6 @@
 # Querystring parsing
 
-React-router-component, as of 0.26.0, understands querystrings.
+React-router-component, as of 0.28.0, understands querystrings.
 
 Querystrings are not matched as part of a route. It is not possible to switch routes
 based on a querystring.


### PR DESCRIPTION
I could be wrong here, but I'm pretty sure issue [#160](https://github.com/STRML/react-router-component/issues/160) shows that query strings aren't actually supported until version 0.28.0?