### PR TITLE
fix for batched updates addon from CDN version of react with 0.14.x

### DIFF
--- a/lib/environment/Environment.js
+++ b/lib/environment/Environment.js
@@ -1,7 +1,7 @@
 "use strict";
 
 // batchedUpdates is now exposed in 0.12
-var batchedUpdates = require('react').batchedUpdates || require('react/lib/ReactUpdates').batchedUpdates;
+var batchedUpdates = require("react-dom").unstable_batchedUpdates || require('react').batchedUpdates || require('react/lib/ReactUpdates').batchedUpdates;
 
 /**
  * Base abstract class for a routing environment.


### PR DESCRIPTION
Use the exposed export from "react-dom". 

Despite its name, all the other exports also refer to the same unstable version of React batched updates. This fixes the application crashing during navigation when used with a CDN version of react.

Note: This is an organic change. Will have to be changed again once the "unstable" tag is dropped.