### PR TITLE
Update Router "component" propType spec.

### DIFF
--- a/lib/Router.js
+++ b/lib/Router.js
@@ -28,7 +28,8 @@ function createRouter(name, component) {
     propTypes: {
       component: React.PropTypes.oneOfType([
         React.PropTypes.string,
-        React.PropTypes.element
+        React.PropTypes.element,
+        React.PropTypes.func
       ])
     },
 


### PR DESCRIPTION
Passing a React Component (which doesn't have a proptype anymore :|) generates a PropType error in the console. This will let it pass. (this mostly matches the handler propType spec, with the addition of string.)
