### PR TITLE
Support filtering named segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## next
+  - Add the ability to decode named segments in routes before they are given as props to handlers. See the [url pattern docs](http://strml.viewdocs.io/react-router-component/override-url-pattern).
+
 ## 0.36.3 (Dec 5, 2016)
   - Reduce npm tarball size by 80% (excluding docs, examples, etc)
 

--- a/docs/override-url-pattern.md
+++ b/docs/override-url-pattern.md
@@ -20,6 +20,36 @@ For example:
       <Location path="/search/*" handler={SearchPage} />
       <Location path={/\/product\/([0-9]*)/} handler={ProductPage} />
     </Locations>
-    ```
+    ...
 
 Overriding the compiler allows you to write very powerful route definitions.
+
+## Centralized named segment value decoding:
+
+Additionally, you may want to decode a value from a named segment such that your handlers see the decoded value.
+
+for example, lets say you have email address usernames. (eg: foo@bar.com) Your routes would be like `/users/foo%40bar.com` and without this config, your handler would get a prop of `username="foo%40bar.com"`. 
+
+In this example, the decoder would ensure that UserPage gets `username="foo@bar.com"` and ***not*** `username="foo%40bar.com"`
+
+```
+const decoders = {
+    //for every named segment, there can be a decode function...
+    username: (value) => decodeURIComponent(value)
+}
+
+function View (props) {
+  return (
+    <Locations 
+      urlPatternOptions={{
+        namedSegmentValueDecoders: decoders, //pass the decoders-map
+        segmentValueCharset: 'a-zA-Z0-9-+_.%' //allow email-like values
+      }}
+    >
+      <Location path="/" handler={MainPage} />
+      <Location path="/users/:username" handler={UserPage} />
+    </Locations>
+  );
+}
+```
+

--- a/docs/override-url-pattern.md
+++ b/docs/override-url-pattern.md
@@ -34,8 +34,8 @@ In this example, the decoder would ensure that UserPage gets `username="foo@bar.
 
 ```
 const decoders = {
-    //for every named segment, there can be a decode function...
-    username: (value) => decodeURIComponent(value)
+  //for every named segment, there can be a decode function...
+  username: (value) => decodeURIComponent(value)
 }
 
 function View (props) {
@@ -53,3 +53,27 @@ function View (props) {
 }
 ```
 
+Also, if you have a single function that handles all the names & values you can pass it in. Ex:
+
+```
+function decodeRouteValues (name, value) {
+  if (name === 'username') {
+    return decodeUsername(value);
+  }
+  return value;
+}
+
+function View (props) {
+  return (
+    <Locations 
+      urlPatternOptions={{
+        namedSegmentValueDecoders: decodeRouteValues, //pass the decoder
+        segmentValueCharset: 'a-zA-Z0-9-+_.%' //allow email-like values
+      }}
+    >
+      <Location path="/" handler={MainPage} />
+      <Location path="/users/:username" handler={UserPage} />
+    </Locations>
+  );
+}
+```

--- a/lib/matchRoutes.js
+++ b/lib/matchRoutes.js
@@ -112,10 +112,12 @@ function Match(path, route, match, query, valueDecoders) {
 
   if (valueDecoders) {    
     Object.keys(match || {}).forEach(function(key) {
-      var fn = valueDecoders[key];
       if (typeof valueDecoders === 'function') {
         match[key] = valueDecoders(key, match[key]);
-      } else if (typeof fn === 'function') {
+        return;
+      }
+      var fn = valueDecoders.hasOwnProperty(key) && valueDecoders[key];
+      if (typeof fn === 'function') {
         match[key] = fn(match[key]);
       }
     });

--- a/lib/matchRoutes.js
+++ b/lib/matchRoutes.js
@@ -94,7 +94,8 @@ function matchRoutes(routes, path, routerURLPatternOptions) {
     pathToMatch,
     page ? page : notFound ? notFound : null,
     match,
-    queryObj
+    queryObj,
+    (urlPatternOptions || {}).namedSegmentValueDecoders
   );
 }
 
@@ -103,11 +104,22 @@ function matchRoutes(routes, path, routerURLPatternOptions) {
  *
  * @private
  */
-function Match(path, route, match, query) {
+function Match(path, route, match, query, valueDecoders) {
   this.path = path;
   this.route = route;
   this.match = match;
   this.query = query;
+
+  if (valueDecoders) {    
+    Object.keys(match || {}).forEach(function(key) {
+      var fn = valueDecoders[key];
+      if (typeof valueDecoders === 'function') {
+        match[key] = valueDecoders(key, match[key]);
+      } else if (typeof fn === 'function') {
+        match[key] = fn(match[key]);
+      }
+    });
+  }
 
   this.unmatchedPath = this.match && this.match._ ?
     this.match._[0] :


### PR DESCRIPTION
...so that route handlers get the decoded value(s)

To do so, pass a urlPatternOptions object with a property
 of `namedSegmentValueDecoders`. This property can be either:
 1) function (name, value) => value
 2) object with {name: function(value) => value, ...}

This provides the functionality described in #189