### PR TITLE
ensure joined routes are slash separated

### DIFF
--- a/lib/RouterMixin.js
+++ b/lib/RouterMixin.js
@@ -224,7 +224,7 @@ var RouterMixin = {
 };
 
 function join(a, b) {
-  return (a + b).replace(/\/\//g, '/');
+  return (a + '/' + b).replace(/\/+/g, '/');
 }
 
 function isString(o) {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "pre-commit": "^1.2.2",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
+    "react-test-renderer": "^16.2.0",
     "semver": "^5.4.1",
     "zuul": "^3.11.1"
   },

--- a/tests/unit/RouterMixin.js
+++ b/tests/unit/RouterMixin.js
@@ -1,0 +1,34 @@
+'use strict';
+import assert      from 'power-assert';
+import React       from 'react';
+import renderer    from 'react-test-renderer';
+import {Location, Locations} from '../../';
+
+describe('RouterMixin', function() {
+    it('RouterMixin join() ensures slash', function () {
+        return new Promise(function (done, fail) {
+            var component = renderer.create(
+                <Locations path="/foo/baz">
+                    <Location path='/foo/:bar(/*)' handler={Sub}/>
+                </Locations>
+            );
+
+            function Sub () {
+                return (
+                    <Locations ref={continueTest} contextual>
+                        <Location path="/" handler={<div/>}/>
+                    </Locations>
+                );
+            }
+
+            function continueTest(subrouter) {
+                try {
+                    assert.strictEqual(subrouter.makeHref('test'), '/foo/baz/test');
+                    done();
+                } catch (e) {
+                    fail(e);
+                }
+            }
+        });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4075,6 +4075,14 @@ react-dom@^16.0.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
+react-test-renderer@^16.2.0:
+  version "16.2.0"
+  resolved "https://npm.nextthought.com/react-test-renderer/-/react-test-renderer-16.2.0.tgz#bddf259a6b8fcd8555f012afc8eacc238872a211"
+  dependencies:
+    fbjs "^0.8.16"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
 react@^16.0.0:
   version "16.0.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.0.0.tgz#ce7df8f1941b036f02b2cca9dbd0cb1f0e855e2d"


### PR DESCRIPTION
The active route may not have a slash at the end, yet if we call makeHref() or navigate() with a deeper segment, the route change fails.